### PR TITLE
Unity setup improvements

### DIFF
--- a/SysKit.ODG.App/SysKit.ODG.App/Configuration/UnityManager.cs
+++ b/SysKit.ODG.App/SysKit.ODG.App/Configuration/UnityManager.cs
@@ -3,7 +3,6 @@ using System.IO;
 using AutoMapper;
 using Serilog;
 using SysKit.ODG.Authentication;
-using SysKit.ODG.Base.Authentication;
 using SysKit.ODG.Base.Interfaces;
 using SysKit.ODG.Base.Interfaces.Authentication;
 using SysKit.ODG.Base.Interfaces.Generation;
@@ -14,13 +13,11 @@ using SysKit.ODG.Generation.Groups;
 using SysKit.ODG.Generation.Sites;
 using SysKit.ODG.Generation.Users;
 using SysKit.ODG.Office365Service;
-using SysKit.ODG.Office365Service.GraphApiManagers;
 using SysKit.ODG.Office365Service.GraphHttpProvider;
 using SysKit.ODG.Office365Service.Polly;
 using SysKit.ODG.Office365Service.SharePoint;
 using SysKit.ODG.SampleData;
 using Unity;
-using Unity.Injection;
 using Unity.Lifetime;
 
 namespace SysKit.ODG.App.Configuration
@@ -39,8 +36,8 @@ namespace SysKit.ODG.App.Configuration
 
             #region Generation services
             
-            container.RegisterSingleton<IGenerationService, GenerationService>();
-            container.RegisterSingleton<IGenerationCleanupService, GenerationCleanupService>();
+            container.RegisterType<IGenerationService, GenerationService>();
+            container.RegisterType<IGenerationCleanupService, GenerationCleanupService>();
             container.RegisterType<IGenerationTask, UserGenerationTask>("userTask");
             container.RegisterType<IGenerationTask, GroupGenerationTask>("groupTask");
             container.RegisterType<IGenerationTask, SiteGenerationTask>("siteTask");


### PR DESCRIPTION
IGenerationService and IGenerationCleanupService registered as types instead of singletons

Since IGenerationService was a singleton, running another generation after the first one would resolve in an error because the _generationTasks dictionary would already contain user/site/group generation task elements from the previous generation, and adding new ones with the same key would result in a duplicate key exception