### PR TITLE
Skip null generation task results for HasErrors

### DIFF
--- a/SysKit.ODG.App/SysKit.ODG.Base/DTO/Generation/Results/GenerationResult.cs
+++ b/SysKit.ODG.App/SysKit.ODG.Base/DTO/Generation/Results/GenerationResult.cs
@@ -13,7 +13,7 @@ namespace SysKit.ODG.Base.DTO.Generation.Results
             GenerationTaskResults = generationTaskResult;
         }
 
-        public bool HasErrors => GenerationTaskResults.Values.Any(v => v.HadErrors);
+        public bool HasErrors => GenerationTaskResults.Values.Any(v => v?.HadErrors ?? false);
 
         public IEnumerable<IGenerationTaskResult> TaskResults => GenerationTaskResults.Values;
     }

--- a/SysKit.ODG.App/SysKit.ODG.Common/DTO/Generation/Results/GenerationResult.cs
+++ b/SysKit.ODG.App/SysKit.ODG.Common/DTO/Generation/Results/GenerationResult.cs
@@ -13,7 +13,7 @@ namespace SysKit.ODG.Base.DTO.Generation.Results
             GenerationTaskResults = generationTaskResult;
         }
 
-        public bool HasErrors => GenerationTaskResults.Values.Any(v => v.HadErrors);
+        public bool HasErrors => GenerationTaskResults.Values.Any(v => v?.HadErrors ?? false);
 
         public IEnumerable<IGenerationTaskResult> TaskResults => GenerationTaskResults.Values;
     }


### PR DESCRIPTION
If our template has, for example, no groups to generate, GenerationResult.GenerationTaskResults will contain null for the GroupGenerationTaskResult since GroupGenerationTask returns null if there is nothing to do (no groups to generate)

HasErrors now considers skipped tasks as successful.